### PR TITLE
Update requirements.txt

### DIFF
--- a/AWS_Rekognition/requirements.txt
+++ b/AWS_Rekognition/requirements.txt
@@ -11,6 +11,7 @@ pyasn1==0.3.6
 Pygments==2.2.0
 python-dateutil==2.6.1
 PyYAML==3.12
+requests==2.22.0
 rsa==3.4.2
 s3transfer==0.1.11
 six==1.11.0


### PR DESCRIPTION
"requests" module is imported in image_helpers.py but not referenced in requirements.txt. Thus the pip install -r requirements.txt command doesnt import a neccessary module. This update resolves that.